### PR TITLE
fix frequent 'premature close' errors

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const through = require('through2')
 const parser = require('@nearform/trace-events-parser')
-const multistream = require('multistream')
+// multistream fork with https://github.com/feross/multistream/pull/47 applied
+const multistream = require('@nearform/multistream')
 const pump = require('pump')
 const fs = require('fs')
 const path = require('path')

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@nearform/trace-events-parser": "^1.0.0",
-    "multistream": "^4.0.0",
+    "@nearform/multistream": "5.0.0-1",
     "pump": "^3.0.0",
     "through2": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@nearform/trace-events-parser": "^1.0.0",
-    "@nearform/multistream": "5.0.0-1",
+    "@nearform/multistream": "5.0.0-2",
     "pump": "^3.0.0",
     "through2": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@nearform/trace-events-parser": "^1.0.0",
-    "multistream": "^2.1.0",
+    "multistream": "^4.0.0",
     "pump": "^3.0.0",
-    "through2": "^2.0.3"
+    "through2": "^3.0.1"
   },
   "devDependencies": {
     "standard": "^11.0.1",


### PR DESCRIPTION
https://github.com/feross/multistream/pull/47 appears to fix frequent crashes in the Clinic.js tools, but hasn't passed review yet. I don't know if that patch is perfect for all cases where multistream can be used, but it certainly does fix Clinic.js's most frequent issues, so perhaps we can start using it here even if it isn't in mainline multistream yet :innocent: 

`@nearform/multistream` is just an `npm publish` ran from that PR's branch with no further changes.